### PR TITLE
feat(identify): implement handling for each identify event

### DIFF
--- a/market/src/handler/identify.rs
+++ b/market/src/handler/identify.rs
@@ -1,6 +1,7 @@
 use libp2p::{identify::Event, Swarm};
+use log::{error, info, warn};
 
-use crate::behaviour::Behaviour;
+use crate::{behaviour::Behaviour, bridge::KAD_PROTOCOL_NAME};
 
 use super::EventHandler;
 
@@ -18,10 +19,28 @@ impl EventHandler for IdentifyHandler<'_> {
     type Event = Event;
     fn handle_event(&mut self, event: Self::Event) {
         match event {
-            Event::Received { peer_id, info } => todo!(),
-            Event::Sent { peer_id } => todo!(),
-            Event::Error { peer_id, error } => todo!(),
-            Event::Pushed { peer_id, info } => todo!(),
+            Event::Received { peer_id, info } => {
+                if info.protocols.contains(&KAD_PROTOCOL_NAME) {
+                    info!(
+                        "[Identify] - {peer_id} supports Kademlia. Adding addresses {:?}",
+                        info.listen_addrs
+                    );
+
+                    for addr in info.listen_addrs {
+                        self.swarm.behaviour_mut().kad.add_address(&peer_id, addr);
+                    }
+                }
+            }
+            Event::Sent { peer_id } => {
+                info!("[Identify] - Identify response sent back to {peer_id}");
+            }
+            Event::Error { peer_id, error } => {
+                error!("[Identify] - Error occurred with {peer_id}: {error}");
+            }
+            Event::Pushed { peer_id, info } => {
+                warn!("[Identify] - Automatically pushed identify information to {peer_id}");
+                warn!("[Identify] - Information pushed: {info:?}");
+            }
         }
     }
 }


### PR DESCRIPTION
# Description

Fixes a part of sbu-416-24sp/orcanet-rust#15


## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Similar to a previous PoC of using the identify protocol. The main thing to look at here is that
1. We won't panic from a `todo` here
2. When we receive an `info` from another peer, we must check that the peer supports our custom named Kademlia protocol `orcanet/kad/1.0.0`. On success, we add each listen address that the peer has advertised.  