### PR TITLE
Market peer merger fileinfo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ peernode/files/*
 peernode/download/*
 !peernode/download/.gitkeep
 peernode/config.json
+config.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2676,6 +2676,7 @@ dependencies = [
  "libp2p",
  "log",
  "pretty_assertions",
+ "proto",
  "serde",
  "thiserror",
  "tokio",
@@ -2755,6 +2756,7 @@ dependencies = [
  "mime_guess",
  "orcanet-market",
  "prost",
+ "proto",
  "rand",
  "reqwest",
  "serde",
@@ -3045,6 +3047,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3235c33eb02c1f1e212abdbe34c78b264b038fb58ca612664343271e36e55ffe"
 dependencies = [
  "prost",
+]
+
+[[package]]
+name = "proto"
+version = "0.1.0"
+dependencies = [
+ "prost",
+ "serde",
+ "sha2",
+ "tonic",
+ "tonic-build",
 ]
 
 [[package]]

--- a/market/Cargo.toml
+++ b/market/Cargo.toml
@@ -40,6 +40,7 @@ tokio = { version = "1.36.0", features = [
   "time",
 ] }
 serde = { version = "1.0.130", features = ["derive"] }
+proto = { path = "../proto"}
 
 [dev-dependencies]
 pretty_assertions = "1.4.0"

--- a/market/src/behaviour.rs
+++ b/market/src/behaviour.rs
@@ -9,7 +9,7 @@ use libp2p::{
     swarm::{behaviour::toggle::Toggle, NetworkBehaviour},
 };
 
-use crate::{lmm::FileHash, SupplierInfo};
+use crate::lmm::{FileInfoHash, SupplierInfo};
 
 // TODO: maybe do somethign with toggle in future?
 
@@ -22,5 +22,5 @@ pub(crate) struct Behaviour {
     pub(crate) relay_server: Toggle<RelayServerBehaviour>,
     pub(crate) dcutr: Toggle<DcutrBehaviour>,
     pub(crate) relay_client: Toggle<RelayClientBehaviour>,
-    pub(crate) req_res: CborReqResBehaviour<FileHash, SupplierInfo>,
+    pub(crate) req_res: CborReqResBehaviour<FileInfoHash, SupplierInfo>,
 }

--- a/market/src/handler/req_res.rs
+++ b/market/src/handler/req_res.rs
@@ -3,7 +3,7 @@ use libp2p::{request_response::Event, Swarm};
 use crate::{
     behaviour::Behaviour,
     command::QueryHandler,
-    lmm::{FileInfoHash, SupplierInfo, LocalMarketMap},
+    lmm::{FileInfoHash, LocalMarketMap, SupplierInfo},
 };
 
 use super::EventHandler;

--- a/market/src/handler/req_res.rs
+++ b/market/src/handler/req_res.rs
@@ -3,8 +3,7 @@ use libp2p::{request_response::Event, Swarm};
 use crate::{
     behaviour::Behaviour,
     command::QueryHandler,
-    lmm::{FileHash, LocalMarketMap},
-    SupplierInfo,
+    lmm::{FileInfoHash, SupplierInfo, LocalMarketMap},
 };
 
 use super::EventHandler;
@@ -30,7 +29,7 @@ impl<'a> ReqResHandler<'a> {
 }
 
 impl<'a> EventHandler for ReqResHandler<'a> {
-    type Event = Event<FileHash, SupplierInfo>;
+    type Event = Event<FileInfoHash, SupplierInfo>;
 
     fn handle_event(&mut self, event: Self::Event) {
         match event {

--- a/market/src/lib.rs
+++ b/market/src/lib.rs
@@ -16,7 +16,6 @@ pub use libp2p::{
     multiaddr::{multiaddr, Protocol},
     Multiaddr,
 };
-pub use lmm::SupplierInfo;
 
 pub(crate) mod behaviour;
 pub(crate) mod command;

--- a/market/src/lmm.rs
+++ b/market/src/lmm.rs
@@ -32,7 +32,10 @@ impl LocalMarketMap {
             .insert(file_info_hash, (Instant::now(), supplier_info));
     }
 
-    pub(crate) fn get_if_not_expired(&mut self, file_info_hash: &FileInfoHash) -> Option<SupplierInfo> {
+    pub(crate) fn get_if_not_expired(
+        &mut self,
+        file_info_hash: &FileInfoHash,
+    ) -> Option<SupplierInfo> {
         if let Some(entry) = self.inner.get(file_info_hash) {
             let elapsed_time = Instant::now().duration_since(entry.0);
             if elapsed_time >= self.file_ttl {
@@ -88,10 +91,7 @@ mod tests {
             file_name: "a_file".to_string(),
         };
         let file_hash = FileInfoHash(file_info.hash_to_string());
-        let supplier_info = SupplierInfo {
-            file_info,
-            user,
-        };
+        let supplier_info = SupplierInfo { file_info, user };
         lmm.insert(file_hash.clone(), supplier_info.clone());
         assert_eq!(lmm.get_if_not_expired(&file_hash), Some(supplier_info));
     }
@@ -113,10 +113,7 @@ mod tests {
             name: "Alice".to_string(),
             id: "416".to_string(),
         };
-        let supplier_info = SupplierInfo {
-            file_info,
-            user,
-        };
+        let supplier_info = SupplierInfo { file_info, user };
         lmm.insert(file_hash.clone(), supplier_info);
         sleep(Duration::from_millis(20));
         assert_eq!(lmm.get_if_not_expired(&file_hash), None);

--- a/market/src/lmm.rs
+++ b/market/src/lmm.rs
@@ -4,13 +4,14 @@ use std::{
     time::{Duration, Instant},
 };
 
+use proto::market::{FileInfo, User};
 use serde::{Deserialize, Serialize};
 
 pub(crate) const FILE_DEFAULT_TTL: Duration = Duration::from_secs(60 * 60);
 
 #[derive(Debug, Clone)]
 pub(crate) struct LocalMarketMap {
-    inner: HashMap<FileHash, LocalMarketEntry>,
+    inner: HashMap<FileInfoHash, LocalMarketEntry>,
     file_ttl: Duration,
 }
 
@@ -26,16 +27,16 @@ impl LocalMarketMap {
         }
     }
 
-    pub(crate) fn insert(&mut self, file_hash: FileHash, supplier_info: SupplierInfo) {
+    pub(crate) fn insert(&mut self, file_info_hash: FileInfoHash, supplier_info: SupplierInfo) {
         self.inner
-            .insert(file_hash, (Instant::now(), supplier_info));
+            .insert(file_info_hash, (Instant::now(), supplier_info));
     }
 
-    pub(crate) fn get_if_not_expired(&mut self, file_hash: &FileHash) -> Option<SupplierInfo> {
-        if let Some(entry) = self.inner.get(file_hash) {
+    pub(crate) fn get_if_not_expired(&mut self, file_info_hash: &FileInfoHash) -> Option<SupplierInfo> {
+        if let Some(entry) = self.inner.get(file_info_hash) {
             let elapsed_time = Instant::now().duration_since(entry.0);
             if elapsed_time >= self.file_ttl {
-                self.inner.remove(file_hash);
+                self.inner.remove(file_info_hash);
                 None
             } else {
                 Some(entry.1.clone())
@@ -56,22 +57,12 @@ pub(crate) type LocalMarketEntry = (Instant, SupplierInfo);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[repr(transparent)]
-pub(crate) struct FileHash(pub(crate) Vec<u8>);
+pub(crate) struct FileInfoHash(pub(crate) String);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub struct SupplierInfo {
-    pub ip: Ipv4Addr,
-    pub port: u16,
-    pub price: i64,
-    pub username: String,
-    pub chunk_data: ChunkMetadata,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub struct ChunkMetadata {
-    // TODO: replace with a concrete type
-    pub chunks: Vec<Vec<u8>>,
-    pub chunk_size: usize,
+pub(crate) struct SupplierInfo {
+    pub(crate) file_info: FileInfo,
+    pub(crate) user: User,
 }
 
 #[cfg(test)]
@@ -83,16 +74,23 @@ mod tests {
     #[test]
     fn test_insert_and_get_if_not_expired() {
         let mut lmm = LocalMarketMap::new(Duration::from_secs(1));
-        let file_hash = FileHash(vec![1]);
-        let supplier_info = SupplierInfo {
-            ip: Ipv4Addr::new(127, 0, 0, 1),
+        let user = User {
+            ip: Ipv4Addr::new(127, 0, 0, 1).to_string(),
             port: 8080,
             price: 100,
-            username: "Alice".to_string(),
-            chunk_data: ChunkMetadata {
-                chunks: vec![vec![1, 2, 3]],
-                chunk_size: 3,
-            },
+            name: "Alice".to_string(),
+            id: "416".to_string(),
+        };
+        let file_info = FileInfo {
+            file_hash: "foo".to_string(),
+            chunk_hashes: vec!["1".into(), "2".into()],
+            file_size: 8000,
+            file_name: "a_file".to_string(),
+        };
+        let file_hash = FileInfoHash(file_info.hash_to_string());
+        let supplier_info = SupplierInfo {
+            file_info,
+            user,
         };
         lmm.insert(file_hash.clone(), supplier_info.clone());
         assert_eq!(lmm.get_if_not_expired(&file_hash), Some(supplier_info));
@@ -101,16 +99,23 @@ mod tests {
     #[test]
     fn test_insert_and_should_expire() {
         let mut lmm = LocalMarketMap::new(Duration::from_millis(10));
-        let file_hash = FileHash(vec![1]);
-        let supplier_info = SupplierInfo {
-            ip: Ipv4Addr::new(127, 0, 0, 1),
+        let file_info = FileInfo {
+            file_hash: "foo".to_string(),
+            chunk_hashes: vec!["1".into(), "2".into()],
+            file_size: 8000,
+            file_name: "a_file".to_string(),
+        };
+        let file_hash = FileInfoHash(file_info.hash_to_string());
+        let user = User {
+            ip: Ipv4Addr::new(127, 0, 0, 1).to_string(),
             port: 8080,
             price: 100,
-            username: "Alice".to_string(),
-            chunk_data: ChunkMetadata {
-                chunks: vec![vec![1, 2, 3]],
-                chunk_size: 3,
-            },
+            name: "Alice".to_string(),
+            id: "416".to_string(),
+        };
+        let supplier_info = SupplierInfo {
+            file_info,
+            user,
         };
         lmm.insert(file_hash.clone(), supplier_info);
         sleep(Duration::from_millis(20));

--- a/peernode/Cargo.toml
+++ b/peernode/Cargo.toml
@@ -32,6 +32,7 @@ config = "0.14.0"
 serde_json = "1.0.115"
 base64 = "0.22.0"
 orcanet-market = { path = "../market" }
+proto = { path = "../proto"}
 
 [build-dependencies]
 tonic-build = "0.11"

--- a/peernode/src/peer-node/cli/mod.rs
+++ b/peernode/src/peer-node/cli/mod.rs
@@ -1,6 +1,7 @@
 use std::str::FromStr;
 
 use crate::consumer;
+use crate::consumer::encode;
 use crate::producer;
 use crate::store;
 
@@ -290,6 +291,12 @@ pub async fn handle_arg_matches(
                         Some(producer) => producer.clone(),
                         None => Err(anyhow!("No producer provided"))?,
                     };
+                    let producer_user = match encode::try_decode_user(&producer) {
+                        Ok(user) => user,
+                        Err(e) => Err(anyhow::anyhow!("Failed to decode producer: {e}"))?,
+                    };
+                    let producer = encode::verify_encoding(&producer)
+                        .expect("We just successfully decoded it.");
                     let chunk_num = match get_matches.get_one::<u64>("CHUNK_NUM") {
                         Some(chunk_num) => *chunk_num,
                         None => 0,
@@ -300,7 +307,7 @@ pub async fn handle_arg_matches(
                     };
                     let token = config.get_token(producer.clone());
                     let ret_token = match consumer::get_file(
-                        producer.clone(),
+                        producer_user,
                         file_hash,
                         token,
                         chunk_num,

--- a/peernode/src/peer-node/consumer/encode.rs
+++ b/peernode/src/peer-node/consumer/encode.rs
@@ -2,16 +2,23 @@ use anyhow::Result;
 use base64::{engine::general_purpose, Engine as _};
 use proto::market::User;
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EncodedUser(String);
+impl EncodedUser {
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+}
+
 // Encode a user struct to a base64 string
-pub fn encode_user(user: &User) -> String {
+pub fn encode_user(user: &User) -> EncodedUser {
     let user_str = serde_json::to_string(&user).unwrap();
-    let encoded_user = general_purpose::STANDARD.encode(user_str.as_bytes());
-    encoded_user
+    EncodedUser(general_purpose::STANDARD.encode(user_str.as_bytes()))
 }
 
 // Decode a base64 string to a user struct
-pub fn decode_user(encoded_user: String) -> Result<User> {
-    let user_str = match general_purpose::STANDARD.decode(&encoded_user) {
+pub fn decode_user(encoded_user: &str) -> Result<User> {
+    let user_str = match general_purpose::STANDARD.decode(encoded_user) {
         Ok(user_str) => match String::from_utf8(user_str) {
             Ok(user_str) => user_str,
             Err(_) => {

--- a/peernode/src/peer-node/consumer/encode.rs
+++ b/peernode/src/peer-node/consumer/encode.rs
@@ -1,8 +1,9 @@
 use anyhow::Result;
 use base64::{engine::general_purpose, Engine as _};
 use proto::market::User;
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct EncodedUser(String);
 impl EncodedUser {
     pub fn as_str(&self) -> &str {
@@ -16,24 +17,30 @@ pub fn encode_user(user: &User) -> EncodedUser {
     EncodedUser(general_purpose::STANDARD.encode(user_str.as_bytes()))
 }
 
+pub fn verify_encoding(encoded_user: &str) -> Result<EncodedUser> {
+    Ok(EncodedUser(
+        match general_purpose::STANDARD.decode(encoded_user) {
+            Ok(user_str) => match String::from_utf8(user_str) {
+                Ok(user_str) => user_str,
+                Err(_) => Err(anyhow::anyhow!("Failed to decode user"))?,
+            },
+            Err(_) => return Err(anyhow::anyhow!("Failed to decode user"))?,
+        },
+    ))
+}
+
 // Decode a base64 string to a user struct
-pub fn decode_user(encoded_user: &str) -> Result<User> {
+pub fn try_decode_user(encoded_user: &str) -> Result<User> {
     let user_str = match general_purpose::STANDARD.decode(encoded_user) {
         Ok(user_str) => match String::from_utf8(user_str) {
             Ok(user_str) => user_str,
-            Err(_) => {
-                return Err(anyhow::anyhow!("Failed to decode user"));
-            }
+            Err(_) => Err(anyhow::anyhow!("Failed to decode user"))?,
         },
-        Err(_) => {
-            return Err(anyhow::anyhow!("Failed to decode user"));
-        }
+        Err(_) => Err(anyhow::anyhow!("Failed to decode user"))?,
     };
 
     match serde_json::from_str(&user_str) {
         Ok(user) => Ok(user),
-        Err(_) => {
-            return Err(anyhow::anyhow!("Failed to parse user"));
-        }
+        Err(_) => Err(anyhow::anyhow!("Failed to parse user"))?,
     }
 }

--- a/peernode/src/peer-node/consumer/encode.rs
+++ b/peernode/src/peer-node/consumer/encode.rs
@@ -1,16 +1,16 @@
 use anyhow::Result;
 use base64::{engine::general_purpose, Engine as _};
-use orcanet_market::SupplierInfo;
+use proto::market::User;
 
 // Encode a user struct to a base64 string
-pub fn encode_user(user: &SupplierInfo) -> String {
+pub fn encode_user(user: &User) -> String {
     let user_str = serde_json::to_string(&user).unwrap();
     let encoded_user = general_purpose::STANDARD.encode(user_str.as_bytes());
     encoded_user
 }
 
 // Decode a base64 string to a user struct
-pub fn decode_user(encoded_user: String) -> Result<SupplierInfo> {
+pub fn decode_user(encoded_user: String) -> Result<User> {
     let user_str = match general_purpose::STANDARD.decode(&encoded_user) {
         Ok(user_str) => match String::from_utf8(user_str) {
             Ok(user_str) => user_str,

--- a/peernode/src/peer-node/consumer/http.rs
+++ b/peernode/src/peer-node/consumer/http.rs
@@ -1,5 +1,5 @@
 use anyhow::{anyhow, Result};
-use orcanet_market::SupplierInfo;
+use proto::market::User;
 
 use std::time::Instant;
 use tokio::fs::OpenOptions;
@@ -11,7 +11,7 @@ pub enum GetFileResponse {
 }
 
 pub async fn get_file_chunk(
-    producer: SupplierInfo,
+    producer: User,
     file_hash: String,
     token: String,
     chunk: u64,

--- a/peernode/src/peer-node/consumer/http.rs
+++ b/peernode/src/peer-node/consumer/http.rs
@@ -19,16 +19,16 @@ pub async fn get_file_chunk(
     let start = Instant::now();
     // Get the link to the file
     let link = format!(
-        "http://{}:{}/file/{}?chunk={}",
-        producer.ip, producer.port, file_hash, chunk
+        "http://{}:{}/file/{file_hash}?chunk={chunk}",
+        producer.ip, producer.port
     );
-    println!("HTTP: Fetching file chunk from {}", link);
+    println!("HTTP: Fetching file chunk from {link}");
 
     // Fetch the file from the producer
     let client = reqwest::Client::new();
     let res = client
         .get(&link)
-        .header("Authorization", format!("Bearer {}", token))
+        .header("Authorization", format!("Bearer {token}"))
         .send()
         .await?;
 
@@ -60,7 +60,7 @@ pub async fn get_file_chunk(
 
     // Save the file to disk
     let file = res.bytes().await?;
-    let file_path = format!("download/{}", file_name);
+    let file_path = format!("download/{file_name}");
     let mut download = OpenOptions::new()
         .create(true)
         .append(true)
@@ -70,9 +70,7 @@ pub async fn get_file_chunk(
     download.write_all(&file).await?;
     let duration = start.elapsed();
     println!(
-        "HTTP: Chunk [{}] saved to {} [{} ms]",
-        chunk,
-        file_name,
+        "HTTP: Chunk [{chunk}] saved to {file_name} [{} ms]",
         duration.as_millis()
     );
     Ok(GetFileResponse::Token(auth_token.to_string()))

--- a/peernode/src/peer-node/consumer/mod.rs
+++ b/peernode/src/peer-node/consumer/mod.rs
@@ -5,7 +5,7 @@ use crate::peer::MarketClient;
 use anyhow::Result;
 use proto::market::User;
 
-use self::{encode::EncodedUser, http::GetFileResponse};
+use self::http::GetFileResponse;
 
 // list every producer who holds the file hash I want
 pub async fn list_producers(file_hash: String, client: &mut MarketClient) -> Result<()> {
@@ -24,24 +24,17 @@ pub async fn list_producers(file_hash: String, client: &mut MarketClient) -> Res
 
 // get file I want by hash from producer
 pub async fn get_file(
-    encoded_producer: String,
+    user: User,
     file_hash: String,
     token: String,
     chunk: u64,
     continue_download: bool,
 ) -> Result<String> {
-    let producer_user = match encode::decode_user(&encoded_producer) {
-        Ok(user) => user,
-        Err(e) => {
-            eprintln!("Failed to decode producer: {}", e);
-            return Err(anyhow::anyhow!("Failed to decode producer"));
-        }
-    };
     let mut chunk_num = chunk;
     let mut return_token = String::from(token);
     loop {
         match get_file_chunk(
-            producer_user.clone(),
+            user.clone(),
             file_hash.clone(),
             return_token.clone(),
             chunk_num,

--- a/peernode/src/peer-node/consumer/mod.rs
+++ b/peernode/src/peer-node/consumer/mod.rs
@@ -5,7 +5,7 @@ use crate::peer::MarketClient;
 use anyhow::Result;
 use proto::market::User;
 
-use self::http::GetFileResponse;
+use self::{encode::EncodedUser, http::GetFileResponse};
 
 // list every producer who holds the file hash I want
 pub async fn list_producers(file_hash: String, client: &mut MarketClient) -> Result<()> {
@@ -15,7 +15,7 @@ pub async fn list_producers(file_hash: String, client: &mut MarketClient) -> Res
         let encoded_producer = encode::encode_user(&producer);
         println!(
             "Producer:\n  id: {}\n  Price: {}",
-            encoded_producer, producer.price
+            encoded_producer.as_str(), producer.price
         );
     }
     Ok(())
@@ -23,13 +23,13 @@ pub async fn list_producers(file_hash: String, client: &mut MarketClient) -> Res
 
 // get file I want by hash from producer
 pub async fn get_file(
-    producer: String,
+    encoded_producer: String,
     file_hash: String,
     token: String,
     chunk: u64,
     continue_download: bool,
 ) -> Result<String> {
-    let producer_user = match encode::decode_user(producer.clone()) {
+    let producer_user = match encode::decode_user(&encoded_producer) {
         Ok(user) => user,
         Err(e) => {
             eprintln!("Failed to decode producer: {}", e);

--- a/peernode/src/peer-node/consumer/mod.rs
+++ b/peernode/src/peer-node/consumer/mod.rs
@@ -3,14 +3,14 @@ pub mod http;
 
 use crate::peer::MarketClient;
 use anyhow::Result;
-use orcanet_market::SupplierInfo;
+use proto::market::User;
 
 use self::http::GetFileResponse;
 
 // list every producer who holds the file hash I want
 pub async fn list_producers(file_hash: String, client: &mut MarketClient) -> Result<()> {
-    let producers = client.check_holders(file_hash).await?;
-    for producer in producers {
+    let response = client.check_holders(file_hash).await?;
+    for producer in response.holders {
         // serialize the producer struct to a string
         let encoded_producer = encode::encode_user(&producer);
         println!(
@@ -72,7 +72,7 @@ pub async fn get_file(
 
 // get individual chunk of file from producer by hash
 pub async fn get_file_chunk(
-    producer: SupplierInfo,
+    producer: User,
     file_hash: String,
     token: String,
     chunk: u64,

--- a/peernode/src/peer-node/consumer/mod.rs
+++ b/peernode/src/peer-node/consumer/mod.rs
@@ -15,7 +15,8 @@ pub async fn list_producers(file_hash: String, client: &mut MarketClient) -> Res
         let encoded_producer = encode::encode_user(&producer);
         println!(
             "Producer:\n  id: {}\n  Price: {}",
-            encoded_producer.as_str(), producer.price
+            encoded_producer.as_str(),
+            producer.price
         );
     }
     Ok(())

--- a/peernode/src/peer-node/peer/mod.rs
+++ b/peernode/src/peer-node/peer/mod.rs
@@ -1,4 +1,6 @@
-use orcanet_market::{bridge::spawn, Config, Peer, SupplierInfo};
+use orcanet_market::{bridge::spawn, Config, Peer};
+
+use proto::market::{FileInfo, HoldersResponse, User};
 
 use anyhow::Result;
 
@@ -17,7 +19,7 @@ impl MarketClient {
     }
 
     // Get a list of producers for a given file hash
-    pub async fn check_holders(&mut self, file_hash: String) -> Result<Vec<SupplierInfo>> {
+    pub async fn check_holders(&mut self, file_hash: String) -> Result<HoldersResponse> {
         todo!()
         // println!("gRPC: Checking holders for file hash {}", file_hash);
         // let request = CheckHoldersRequest { file_hash };

--- a/peernode/src/peer-node/store/mod.rs
+++ b/peernode/src/peer-node/store/mod.rs
@@ -1,5 +1,5 @@
-use crate::peer::MarketClient;
 use crate::producer;
+use crate::{consumer::encode::EncodedUser, peer::MarketClient};
 use anyhow::Result;
 use config::{Config, File, FileFormat};
 use orcanet_market::{BootNodes, Multiaddr};
@@ -21,7 +21,7 @@ pub struct Properties {
     market: String,
     files: HashMap<String, PathBuf>,
     prices: HashMap<String, i64>,
-    tokens: HashMap<String, String>,
+    tokens: HashMap<EncodedUser, String>,
     port: String,
     // market config
     boot_nodes: Option<BootNodes>,
@@ -126,7 +126,7 @@ impl Configurations {
         self.props.public_address.clone()
     }
 
-    pub fn get_token(&mut self, producer_id: String) -> String {
+    pub fn get_token(&mut self, producer_id: EncodedUser) -> String {
         match self.props.tokens.get(&producer_id).cloned() {
             Some(token) => token,
             None => {
@@ -138,7 +138,7 @@ impl Configurations {
         }
     }
 
-    pub fn set_token(&mut self, producer_id: String, token: String) {
+    pub fn set_token(&mut self, producer_id: EncodedUser, token: String) {
         self.props.tokens.insert(producer_id, token);
         self.write();
     }
@@ -155,6 +155,7 @@ impl Configurations {
 
     pub fn set_public_address(&mut self, public_address: Option<Multiaddr>) {
         self.props.public_address = public_address;
+        self.write();
     }
 
     // add every file in the directory to the list

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "proto"
+edition = "2021"
+version = "0.1.0"
+
+[dependencies]
+prost = "0.12.3"
+serde = { version = "1.0.197", features = ["derive"] }
+sha2 = "0.10.8"
+tonic = "0.11.0"
+
+[build-dependencies]
+tonic-build = "0.11.0"

--- a/proto/build.rs
+++ b/proto/build.rs
@@ -1,0 +1,21 @@
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    //tonic_build::compile_protos("../../proto/market.proto")?;
+    tonic_build::configure()
+        .type_attribute(
+            "User", 
+            "#[derive(Eq, Hash, serde::Deserialize, serde::Serialize)]"
+        )
+        .type_attribute(
+            "FileInfo",
+            "#[derive(Eq, serde::Deserialize, serde::Serialize)]",
+        )
+        .type_attribute(
+            "HoldersResponse",
+            "#[derive(Eq, serde::Deserialize, serde::Serialize)]",
+        )
+        .compile(&["market.proto"], &["."])?;
+    
+    println!("cargo:rerun-if-changed=market.proto");
+    println!("cargo:rerun-if-changed=.");
+    Ok(())
+}

--- a/proto/build.rs
+++ b/proto/build.rs
@@ -2,8 +2,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     //tonic_build::compile_protos("../../proto/market.proto")?;
     tonic_build::configure()
         .type_attribute(
-            "User", 
-            "#[derive(Eq, Hash, serde::Deserialize, serde::Serialize)]"
+            "User",
+            "#[derive(Eq, Hash, serde::Deserialize, serde::Serialize)]",
         )
         .type_attribute(
             "FileInfo",
@@ -14,7 +14,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             "#[derive(Eq, serde::Deserialize, serde::Serialize)]",
         )
         .compile(&["market.proto"], &["."])?;
-    
+
     println!("cargo:rerun-if-changed=market.proto");
     println!("cargo:rerun-if-changed=.");
     Ok(())

--- a/proto/market.proto
+++ b/proto/market.proto
@@ -1,0 +1,54 @@
+// keep up to date with spec:
+// https://gist.github.com/snitski/83a603e926c973862370cba1d3cb1e87
+
+syntax = "proto3";
+
+import "google/protobuf/empty.proto";
+
+option go_package = "orcanet/market/market";
+
+package market;
+
+service Market {
+  // Register a file on the market
+  rpc RegisterFile (RegisterFileRequest) returns (google.protobuf.Empty) {}
+
+  // Check for holders of a file. returns a list of users
+  rpc CheckHolders (CheckHoldersRequest) returns (HoldersResponse) {}
+}
+
+message User {
+  string id = 1;
+  string name = 2;
+
+  string ip = 3;
+  int32 port = 4;
+
+  // Price per MB for a file
+  int64 price = 5;
+}
+
+message FileInfo {
+  string fileHash = 1;
+  repeated string chunkHashes = 2;
+
+  // Size of the file in Bytes
+  int64 fileSize = 3;
+  string fileName = 4;
+}
+
+message CheckHoldersRequest {
+  // Hash of FileInfo
+  string fileKey = 1; 
+}
+
+message RegisterFileRequest {
+  User user = 1;
+  // Hash of FileInfo
+  string fileKey = 2;
+}
+
+message HoldersResponse {
+  FileInfo fileInfo = 1;
+  repeated User holders = 2;
+}

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -3,7 +3,7 @@ pub mod market {
 
     use sha2::{Digest, Sha256};
     use std::hash::{Hash, Hasher};
-    
+
     // this is unnecessary I think
     impl Hash for FileInfo {
         fn hash<H: Hasher>(&self, state: &mut H) {
@@ -31,5 +31,4 @@ pub mod market {
             format!("{:x}", sha256.finalize())
         }
     }
-
 }

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -1,0 +1,35 @@
+pub mod market {
+    tonic::include_proto!("market"); // The string specified here must match the proto package name
+
+    use sha2::{Digest, Sha256};
+    use std::hash::{Hash, Hasher};
+    
+    // this is unnecessary I think
+    impl Hash for FileInfo {
+        fn hash<H: Hasher>(&self, state: &mut H) {
+            let mut input = self.file_hash.clone();
+            for chunk_hash in &self.chunk_hashes {
+                input += chunk_hash;
+            }
+            input += self.file_size.to_string().as_str();
+            input += self.file_name.as_str();
+            input.hash(state);
+        }
+    }
+
+    impl FileInfo {
+        // from doc
+        pub fn hash_to_string(self: &FileInfo) -> String {
+            let mut sha256 = Sha256::new();
+            let mut input = self.file_hash.clone();
+            for chunk_hash in &self.chunk_hashes {
+                input += chunk_hash;
+            }
+            input += self.file_size.to_string().as_str();
+            input += self.file_name.as_str();
+            sha256.update(input);
+            format!("{:x}", sha256.finalize())
+        }
+    }
+
+}


### PR DESCRIPTION
# Description

Updates the datatypes used throughout the market and peer to match the ones in Alex's Peernode hashing guidelines: https://docs.google.com/document/d/1IfiCf2OMkDiqluHIxmNPOc2y4UB7WDJXR_fflhfca0A/edit#heading=h.vj8i0zfr8v86

## Comments

I am unsure of how the data should be stored in LocalMarketMap, I currently set it up so the FileInfo and User is stored together as a SupplierInfo struct in the map, should that simply be User or something different altogether?

I set up the datatypes in the proto/ folder with a copy of the market.proto file, should that be set up as a link as well?