### PR TITLE
feat(kad): add handlers for inbound request events

### DIFF
--- a/market/src/handler/kad.rs
+++ b/market/src/handler/kad.rs
@@ -1,4 +1,8 @@
-use libp2p::{kad::Event, Swarm};
+use libp2p::{
+    kad::{Event, InboundRequest},
+    Swarm,
+};
+use log::{info, warn};
 
 use crate::{behaviour::Behaviour, command::QueryHandler, lmm::LocalMarketMap};
 
@@ -22,6 +26,27 @@ impl<'a> KadHandler<'a> {
             query_handler,
         }
     }
+
+    pub(crate) fn handle_inbound_request(&mut self, request: InboundRequest) {
+        match request {
+            InboundRequest::FindNode { num_closer_peers } => {
+                warn!("[Kademlia] - FindNode request received and handled");
+                info!("[Kademlia] - The number of closest peers found {num_closer_peers}");
+            }
+            InboundRequest::GetProvider {
+                num_closer_peers,
+                num_provider_peers,
+            } => {
+                warn!("[Kademlia] - GetProvider request received and handled");
+                info!("[Kademlia] - The number of closest peers found {num_closer_peers}");
+                info!("[Kademlia] - The number of provider peers found {num_provider_peers} for this particular key");
+            }
+            InboundRequest::AddProvider { .. } => {
+                warn!("[Kademlia] - AddProvider request received and handled");
+            }
+            _ => {}
+        }
+    }
 }
 
 impl<'a> EventHandler for KadHandler<'a> {
@@ -29,7 +54,7 @@ impl<'a> EventHandler for KadHandler<'a> {
 
     fn handle_event(&mut self, event: Self::Event) {
         match event {
-            Event::InboundRequest { request } => todo!(),
+            Event::InboundRequest { request } => self.handle_inbound_request(request),
             Event::OutboundQueryProgressed {
                 id,
                 result,


### PR DESCRIPTION
# Description

Handles events for relevant inbound requests events that comes from the Kademlia protocol events that are emitted by the swarm. I think these logs are useful enough, but feel free to provide feedback if we can something more meaningful when events are being logged.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
Similar to other events, it's just more sanity logging since the swarm handles what those events are supposed to do in the background. It successfully compiled as well.