### PR TITLE
feat(kad): add a get closest peers method for user

### DIFF
--- a/market/src/bridge/peer.rs
+++ b/market/src/bridge/peer.rs
@@ -67,9 +67,11 @@ impl Peer {
     }
 
     #[inline(always)]
-    pub async fn get_closest_peers(&self, key: Vec<u8>) -> Response {
-        self.send(Request::KadRequest(KadRequest::GetClosestPeers { key }))
-            .await
+    pub async fn get_closest_peers(&self, key: impl Into<Vec<u8>>) -> Response {
+        self.send(Request::KadRequest(KadRequest::GetClosestPeers {
+            key: key.into(),
+        }))
+        .await
     }
 
     #[inline(always)]

--- a/market/src/bridge/peer.rs
+++ b/market/src/bridge/peer.rs
@@ -5,6 +5,7 @@ use proto::market::User;
 use tokio::sync::mpsc;
 use tokio::sync::oneshot;
 
+use crate::command::request::KadRequest;
 use crate::command::Message;
 use crate::FailureResponse;
 use crate::FileInfoHash;
@@ -63,6 +64,12 @@ impl Peer {
     #[inline(always)]
     pub async fn connected_to(&self, peer_id: PeerId) -> Response {
         self.send(Request::ConnectedTo { peer_id }).await
+    }
+
+    #[inline(always)]
+    pub async fn get_closest_peers(&self, key: Vec<u8>) -> Response {
+        self.send(Request::KadRequest(KadRequest::GetClosestPeers { key }))
+            .await
     }
 
     #[inline(always)]

--- a/market/src/command/request.rs
+++ b/market/src/command/request.rs
@@ -1,14 +1,20 @@
 use libp2p::{kad::QueryId, request_response::OutboundRequestId, PeerId};
 
-#[derive(Debug, PartialEq, Eq, Hash)]
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub(crate) enum Query {
     Kad(QueryId),
     ReqRes(OutboundRequestId),
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub(crate) enum Request {
     Listeners,
     ConnectedPeers,
     ConnectedTo { peer_id: PeerId },
+    KadRequest(KadRequest),
+}
+
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
+pub(crate) enum KadRequest {
+    GetClosestPeers { key: Vec<u8> },
 }

--- a/market/src/command/response.rs
+++ b/market/src/command/response.rs
@@ -9,6 +9,7 @@ pub enum SuccessfulResponse {
     Listeners { listeners: Vec<Multiaddr> },
     ConnectedPeers { peers: Vec<PeerId> },
     ConnectedTo { connected: bool },
+    KadResponse(KadSuccessfulResponse),
 }
 
 #[derive(Debug, Error)]
@@ -17,4 +18,17 @@ pub enum FailureResponse {
     SendError(String),
     #[error("Failed to receive response: {0}")]
     RecvError(#[from] RecvError),
+    #[error("[Kademlia Error] - {0}")]
+    KadError(KadFailureResponse),
+}
+
+#[derive(Debug)]
+pub enum KadSuccessfulResponse {
+    GetClosestPeers { peers: Vec<PeerId> },
+}
+
+#[derive(Debug, Error)]
+pub enum KadFailureResponse {
+    #[error("Failed to get closest peers: {error}")]
+    GetClosestPeers { key: Vec<u8>, error: String },
 }

--- a/market/src/handler/mod.rs
+++ b/market/src/handler/mod.rs
@@ -27,7 +27,8 @@ pub(crate) trait EventHandler {
 }
 
 pub(crate) trait CommandRequestHandler {
-    fn handle_command(&mut self, request: Request, responder: oneshot::Sender<Response>);
+    type Request;
+    fn handle_command(&mut self, request: Self::Request, responder: oneshot::Sender<Response>);
 }
 
 // NOTE: one lifetime should be covariant enough?
@@ -245,6 +246,7 @@ impl<'a> EventHandler for Handler<'a> {
 }
 
 impl<'a> CommandRequestHandler for Handler<'a> {
+    type Request = Request;
     fn handle_command(&mut self, request: Request, responder: oneshot::Sender<Response>) {
         match request {
             Request::Listeners => {
@@ -259,6 +261,7 @@ impl<'a> CommandRequestHandler for Handler<'a> {
                 let connected = self.swarm.is_connected(&peer_id);
                 send_ok!(responder, SuccessfulResponse::ConnectedTo { connected });
             }
+            Request::KadRequest(kad_request) => {}
         };
     }
 }

--- a/market/src/handler/mod.rs
+++ b/market/src/handler/mod.rs
@@ -261,7 +261,10 @@ impl<'a> CommandRequestHandler for Handler<'a> {
                 let connected = self.swarm.is_connected(&peer_id);
                 send_ok!(responder, SuccessfulResponse::ConnectedTo { connected });
             }
-            Request::KadRequest(kad_request) => {}
+            Request::KadRequest(kad_request) => {
+                let mut handler = KadHandler::new(self.swarm, self.lmm, self.query_handler);
+                handler.handle_command(kad_request, responder);
+            }
         };
     }
 }


### PR DESCRIPTION
# Description
We now add a `get_closest_peers` method that a user can use. A user can provide a key via some type that implements the `Into<Vec<u8>>` trait.

Based similar to one of our older PoCs around [here](https://github.com/reaovyd/orcanet-market-rust/blob/main/market_dht/src/behaviour/kademlia.rs)