### PR TITLE
feat(kad): implement the register_file method

### DIFF
--- a/market/src/bridge/peer.rs
+++ b/market/src/bridge/peer.rs
@@ -83,8 +83,14 @@ impl Peer {
     pub async fn register_file(
         &self,
         user: impl Into<User>,
-        fileinfo: impl Into<FileInfo>,
+        file_info_hash: impl Into<FileInfoHash>,
+        file_info: impl Into<FileInfo>,
     ) -> Response {
-        todo!()
+        self.send(Request::Kad(KadRequest::RegisterFile {
+            file_info_hash: file_info_hash.into(),
+            file_info: file_info.into(),
+            user: user.into(),
+        }))
+        .await
     }
 }

--- a/market/src/command/request.rs
+++ b/market/src/command/request.rs
@@ -1,4 +1,7 @@
 use libp2p::{kad::QueryId, request_response::OutboundRequestId, PeerId};
+use proto::market::{FileInfo, User};
+
+use crate::FileInfoHash;
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub(crate) enum Query {
@@ -16,5 +19,12 @@ pub(crate) enum Request {
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub(crate) enum KadRequest {
-    GetClosestPeers { key: Vec<u8> },
+    GetClosestPeers {
+        key: Vec<u8>,
+    },
+    RegisterFile {
+        file_info_hash: FileInfoHash,
+        file_info: FileInfo,
+        user: User,
+    },
 }

--- a/market/src/command/response.rs
+++ b/market/src/command/response.rs
@@ -4,7 +4,7 @@ use tokio::sync::oneshot::error::RecvError;
 
 pub type Response = Result<SuccessfulResponse, FailureResponse>;
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum SuccessfulResponse {
     Listeners { listeners: Vec<Multiaddr> },
     ConnectedPeers { peers: Vec<PeerId> },
@@ -12,7 +12,7 @@ pub enum SuccessfulResponse {
     KadResponse(KadSuccessfulResponse),
 }
 
-#[derive(Debug, Error)]
+#[derive(Debug, PartialEq, Eq, Error)]
 pub enum FailureResponse {
     #[error("Failed to send request: {0}")]
     SendError(String),
@@ -22,13 +22,13 @@ pub enum FailureResponse {
     KadError(KadFailureResponse),
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum KadSuccessfulResponse {
     GetClosestPeers { peers: Vec<PeerId> },
     RegisterFile,
 }
 
-#[derive(Debug, Error)]
+#[derive(Debug, PartialEq, Eq, Error)]
 pub enum KadFailureResponse {
     #[error("Failed to get closest peers: {error}")]
     GetClosestPeers { key: Vec<u8>, error: String },

--- a/market/src/command/response.rs
+++ b/market/src/command/response.rs
@@ -25,10 +25,13 @@ pub enum FailureResponse {
 #[derive(Debug)]
 pub enum KadSuccessfulResponse {
     GetClosestPeers { peers: Vec<PeerId> },
+    RegisterFile,
 }
 
 #[derive(Debug, Error)]
 pub enum KadFailureResponse {
     #[error("Failed to get closest peers: {error}")]
     GetClosestPeers { key: Vec<u8>, error: String },
+    #[error("Failed to register file: {error}")]
+    RegisterFile { error: String },
 }

--- a/market/src/lmm.rs
+++ b/market/src/lmm.rs
@@ -1,6 +1,5 @@
 use std::{
     collections::HashMap,
-    net::Ipv4Addr,
     time::{Duration, Instant},
 };
 
@@ -62,9 +61,27 @@ pub(crate) type LocalMarketEntry = (Instant, SupplierInfo);
 #[repr(transparent)]
 pub struct FileInfoHash(String);
 
+impl FileInfoHash {
+    #[inline(always)]
+    pub const fn new(s: String) -> Self {
+        Self(s)
+    }
+
+    #[inline(always)]
+    pub(crate) fn into_bytes(self) -> Vec<u8> {
+        self.into()
+    }
+}
+
 impl From<String> for FileInfoHash {
     fn from(s: String) -> Self {
         Self(s)
+    }
+}
+
+impl From<FileInfoHash> for Vec<u8> {
+    fn from(value: FileInfoHash) -> Self {
+        value.0.into_bytes()
     }
 }
 
@@ -78,7 +95,7 @@ pub(crate) struct SupplierInfo {
 mod tests {
     use super::*;
     use pretty_assertions::assert_eq;
-    use std::thread::sleep;
+    use std::{net::Ipv4Addr, thread::sleep};
 
     #[test]
     fn test_insert_and_get_if_not_expired() {

--- a/market/tests/test_register_file.rs
+++ b/market/tests/test_register_file.rs
@@ -1,0 +1,23 @@
+use orcanet_market::{bridge::spawn, Config, FileInfoHash};
+use proto::market::{FileInfo, User};
+
+#[tokio::test]
+async fn test_register_file() {
+    let peer = spawn(Config::default()).unwrap();
+    let user = User {
+        id: "abc".to_string(),
+        name: "helloworld".to_string(),
+        ip: "127.0.0.1".to_string(),
+        port: 6666,
+        price: 32,
+    };
+    let file_info = FileInfo {
+        file_hash: "123abc".to_string(),
+        chunk_hashes: vec!["hi".to_string()],
+        file_size: 3212321,
+        file_name: "fooobar.mp4".to_owned(),
+    };
+    let file_info_hash = FileInfoHash::new(file_info.hash_to_string());
+    let res = peer.register_file(user, file_info_hash, file_info).await;
+    println!("{:?}", res);
+}

--- a/market/tests/test_register_file.rs
+++ b/market/tests/test_register_file.rs
@@ -1,4 +1,6 @@
-use orcanet_market::{bridge::spawn, Config, FileInfoHash};
+use orcanet_market::{
+    bridge::spawn, Config, FileInfoHash, KadSuccessfulResponse, SuccessfulResponse,
+};
 use proto::market::{FileInfo, User};
 
 #[tokio::test]
@@ -19,5 +21,10 @@ async fn test_register_file() {
     };
     let file_info_hash = FileInfoHash::new(file_info.hash_to_string());
     let res = peer.register_file(user, file_info_hash, file_info).await;
-    println!("{:?}", res);
+    assert_eq!(
+        res,
+        Ok(SuccessfulResponse::KadResponse(
+            KadSuccessfulResponse::RegisterFile
+        ))
+    )
 }


### PR DESCRIPTION
# Description

Fixes sbu-416-24sp/orcanet-rust#17.

We implement the `register_file` method with this PR here. To showcase it working with an end to end test, the `check_holders` method would have to be implemented (which will be done in a future PR). But, the libp2p swarm handles dealing with the provider record things in the background.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] `test_register_file` is a basic test with a single test that tests the behavior of testing this registering of a file.
- [x] Compiles with `cargo test test_register_file`; links to the library so the library compiles

## Running `test_register_file` on my machine
![image](https://github.com/daminals/orcanet-rust/assets/65320857/2d604c1c-4fd7-4515-9ff7-7fd9e0163c5a)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works (somewhat. Autonat isn't implemented so typically would crash due to `todo`, but the behavior of the method would be the same regardless.)
- [x] New and existing unit tests pass locally with my changes