### PR TITLE
feat(kad): add a peer method to get providers/peer ids from hash

### DIFF
--- a/market/src/bridge/peer.rs
+++ b/market/src/bridge/peer.rs
@@ -75,6 +75,14 @@ impl Peer {
     }
 
     #[inline(always)]
+    pub async fn get_providers(&self, file_info_hash: impl Into<FileInfoHash>) -> Response {
+        self.send(Request::Kad(KadRequest::GetProviders {
+            file_info_hash: file_info_hash.into(),
+        }))
+        .await
+    }
+
+    #[inline(always)]
     pub async fn check_holders(&self, file_info: impl Into<FileInfoHash>) -> Response {
         todo!()
     }

--- a/market/src/command/request.rs
+++ b/market/src/command/request.rs
@@ -15,6 +15,7 @@ pub(crate) enum Request {
     ConnectedPeers,
     ConnectedTo { peer_id: PeerId },
     Kad(KadRequest),
+    LocalMarketMap(LmmRequest),
 }
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
@@ -30,4 +31,9 @@ pub(crate) enum KadRequest {
     GetProviders {
         file_info_hash: FileInfoHash,
     },
+}
+
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
+pub(crate) enum LmmRequest {
+    IsLocalFileOwner { file_info_hash: FileInfoHash },
 }

--- a/market/src/command/request.rs
+++ b/market/src/command/request.rs
@@ -27,4 +27,7 @@ pub(crate) enum KadRequest {
         file_info: FileInfo,
         user: User,
     },
+    GetProviders {
+        file_info_hash: FileInfoHash,
+    },
 }

--- a/market/src/command/response.rs
+++ b/market/src/command/response.rs
@@ -1,5 +1,3 @@
-use std::collections::HashSet;
-
 use libp2p::{Multiaddr, PeerId};
 use thiserror::Error;
 use tokio::sync::oneshot::error::RecvError;
@@ -7,14 +5,17 @@ use tokio::sync::oneshot::error::RecvError;
 pub type Response = Result<SuccessfulResponse, FailureResponse>;
 
 #[derive(Debug, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum SuccessfulResponse {
     Listeners { listeners: Vec<Multiaddr> },
     ConnectedPeers { peers: Vec<PeerId> },
     ConnectedTo { connected: bool },
     KadResponse(KadSuccessfulResponse),
+    LmmResponse(LmmSuccessfulResponse),
 }
 
 #[derive(Debug, PartialEq, Eq, Error)]
+#[non_exhaustive]
 pub enum FailureResponse {
     #[error("Failed to send request: {0}")]
     SendError(String),
@@ -22,24 +23,35 @@ pub enum FailureResponse {
     RecvError(#[from] RecvError),
     #[error("[Kademlia Error] - {0}")]
     KadError(KadFailureResponse),
+    #[error("[Local Market Map Error] - {0}")]
+    LmmError(LmmFailureResponse),
 }
 
 #[derive(Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum LmmSuccessfulResponse {
+    IsLocalFileOwner { is_owner: bool },
+}
+
+#[derive(Debug, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum KadSuccessfulResponse {
     GetClosestPeers { peers: Vec<PeerId> },
     RegisterFile,
-    GetProviders { providers: HashSet<PeerId> },
+    GetProviders { providers: Vec<PeerId> },
 }
 
 #[derive(Debug, PartialEq, Eq, Error)]
+#[non_exhaustive]
 pub enum KadFailureResponse {
     #[error("Failed to get closest peers: {error}")]
     GetClosestPeers { key: Vec<u8>, error: String },
     #[error("Failed to register file: {error}")]
     RegisterFile { error: String },
     #[error("Failed to get providers: {error}")]
-    GetProviders {
-        closest_peers: Vec<PeerId>,
-        error: String,
-    },
+    GetProviders { error: String },
 }
+
+#[derive(Debug, PartialEq, Eq, Error)]
+#[non_exhaustive]
+pub enum LmmFailureResponse {}

--- a/market/src/command/response.rs
+++ b/market/src/command/response.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use libp2p::{Multiaddr, PeerId};
 use thiserror::Error;
 use tokio::sync::oneshot::error::RecvError;
@@ -26,6 +28,7 @@ pub enum FailureResponse {
 pub enum KadSuccessfulResponse {
     GetClosestPeers { peers: Vec<PeerId> },
     RegisterFile,
+    GetProviders { providers: HashSet<PeerId> },
 }
 
 #[derive(Debug, PartialEq, Eq, Error)]
@@ -34,4 +37,9 @@ pub enum KadFailureResponse {
     GetClosestPeers { key: Vec<u8>, error: String },
     #[error("Failed to register file: {error}")]
     RegisterFile { error: String },
+    #[error("Failed to get providers: {error}")]
+    GetProviders {
+        closest_peers: Vec<PeerId>,
+        error: String,
+    },
 }

--- a/market/src/handler/kad.rs
+++ b/market/src/handler/kad.rs
@@ -111,18 +111,19 @@ impl<'a> KadHandler<'a> {
                                 self.query_handler.respond(
                                     Query::Kad(qid),
                                     Ok(SuccessfulResponse::KadResponse(
-                                        KadSuccessfulResponse::GetProviders { providers },
+                                        KadSuccessfulResponse::GetProviders {
+                                            providers: providers.into_iter().collect(),
+                                        },
                                     )),
                                 );
                             }
-                            GetProvidersOk::FinishedWithNoAdditionalRecord { closest_peers } => {
+                            GetProvidersOk::FinishedWithNoAdditionalRecord { .. } => {
                                 warn!("[Kademlia] - GetProviders query didn't necessarily fail, but no additional records were found.");
                                 self.query_handler.respond(
                                     Query::Kad(qid),
-                                    Err(FailureResponse::KadError(
-                                        KadFailureResponse::GetProviders {
-                                            closest_peers,
-                                            error: "no additional records found".to_owned(),
+                                    Ok(SuccessfulResponse::KadResponse(
+                                        KadSuccessfulResponse::GetProviders {
+                                            providers: Default::default(),
                                         },
                                     )),
                                 );
@@ -130,13 +131,12 @@ impl<'a> KadHandler<'a> {
                         }
                     };
                 }
-                Err(GetProvidersError::Timeout { closest_peers, .. }) => {
+                Err(GetProvidersError::Timeout { .. }) => {
                     error!("[Kademlia] - GetProviders query failed due to timeout.");
                     self.query_handler.respond(
                         Query::Kad(qid),
                         Err(FailureResponse::KadError(
                             KadFailureResponse::GetProviders {
-                                closest_peers,
                                 error: "timeout".to_owned(),
                             },
                         )),

--- a/market/src/handler/kad.rs
+++ b/market/src/handler/kad.rs
@@ -1,7 +1,7 @@
 use libp2p::{
     kad::{
         AddProviderError, AddProviderOk, BootstrapError, Event, GetClosestPeersError,
-        InboundRequest, ProgressStep, QueryId, QueryResult,
+        GetProvidersError, GetProvidersOk, InboundRequest, ProgressStep, QueryId, QueryResult,
     },
     Swarm,
 };
@@ -102,7 +102,47 @@ impl<'a> KadHandler<'a> {
                     }
                 }
             }
-            QueryResult::GetProviders(_) => todo!(),
+            QueryResult::GetProviders(result) => match result {
+                Ok(maybe_ok) => {
+                    if step.last {
+                        match maybe_ok {
+                            GetProvidersOk::FoundProviders { providers, .. } => {
+                                info!("[Kademlia] - GetProviders query successful");
+                                self.query_handler.respond(
+                                    Query::Kad(qid),
+                                    Ok(SuccessfulResponse::KadResponse(
+                                        KadSuccessfulResponse::GetProviders { providers },
+                                    )),
+                                );
+                            }
+                            GetProvidersOk::FinishedWithNoAdditionalRecord { closest_peers } => {
+                                warn!("[Kademlia] - GetProviders query didn't necessarily fail, but no additional records were found.");
+                                self.query_handler.respond(
+                                    Query::Kad(qid),
+                                    Err(FailureResponse::KadError(
+                                        KadFailureResponse::GetProviders {
+                                            closest_peers,
+                                            error: "no additional records found".to_owned(),
+                                        },
+                                    )),
+                                );
+                            }
+                        }
+                    };
+                }
+                Err(GetProvidersError::Timeout { closest_peers, .. }) => {
+                    error!("[Kademlia] - GetProviders query failed due to timeout.");
+                    self.query_handler.respond(
+                        Query::Kad(qid),
+                        Err(FailureResponse::KadError(
+                            KadFailureResponse::GetProviders {
+                                closest_peers,
+                                error: "timeout".to_owned(),
+                            },
+                        )),
+                    );
+                }
+            },
             QueryResult::StartProviding(result) => match result {
                 Ok(AddProviderOk { .. }) => {
                     info!("[Kademlia] - StartProviding query successful");
@@ -209,6 +249,14 @@ impl<'a> CommandRequestHandler for KadHandler<'a> {
                         );
                     }
                 };
+            }
+            KadRequest::GetProviders { file_info_hash } => {
+                let qid = self
+                    .swarm
+                    .behaviour_mut()
+                    .kad
+                    .get_providers(file_info_hash.into_bytes().into());
+                self.query_handler.add_query(Query::Kad(qid), responder);
             }
         }
     }

--- a/market/tests/test_register_file.rs
+++ b/market/tests/test_register_file.rs
@@ -28,3 +28,37 @@ async fn test_register_file() {
         ))
     )
 }
+
+#[tokio::test]
+async fn test_register_and_get_providers() {
+    let config = Config::builder().set_peer_tcp_port(14000).build();
+    let peer = spawn(config).unwrap();
+    let peer_id = peer.peer_id();
+    let user = User {
+        id: "abc".to_string(),
+        name: "helloworld".to_string(),
+        ip: "127.0.0.1".to_string(),
+        port: 6666,
+        price: 32,
+    };
+    let file_info = FileInfo {
+        file_hash: "123abc".to_string(),
+        chunk_hashes: vec!["hi".to_string()],
+        file_size: 3212321,
+        file_name: "fooobar.mp4".to_owned(),
+    };
+    let file_info_hash = FileInfoHash::new(file_info.hash_to_string());
+    let _ = peer
+        .register_file(user, file_info_hash.clone(), file_info)
+        .await;
+    let res = peer.get_providers(file_info_hash).await;
+    let expected_providers = vec![*peer_id];
+    assert_eq!(
+        res,
+        Ok(SuccessfulResponse::KadResponse(
+            KadSuccessfulResponse::GetProviders {
+                providers: expected_providers
+            }
+        ))
+    );
+}


### PR DESCRIPTION
# Description

Related to sbu-416-24sp/orcanet-rust#18.

This is a method that allows a user to get the peer ids based on a `FileInfoHash`. This is for the purpose of getting one step closer to the implementation of `check_holders`.

We also introduce another method called `is_local_file_owner` which allows a user to ask the `lmm.rs` if they are currently an owner of the file which is necessary since `GetProviders` doesn't return self as a provider. We have this information stored in the `lmm` so we just need to ask the `lmm` for that information.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] `test_register_file.rs` now has another test `test_register_and_get_providers`, which registers a file and then tests that the only spawned peer that provided that file owns that file. Asserts that we get exactly one owner of the file: the only spawned peer.
- [x] Compiles with `cargo test --test test_register_file; links to the library so the library compiles

## Running `test_register_file` on my machine
![image](https://github.com/daminals/orcanet-rust/assets/65320857/5bf5d127-0e0a-4b53-a74d-4e1e1321ee53)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works (somewhat. Autonat isn't implemented so typically would crash due to `todo`, but the behavior of the method would be the same regardless.)
- [x] New and existing unit tests pass locally with my changes