### PR TITLE
feat(check_holders): implement the get_holder_by_id method

### DIFF
--- a/market/src/behaviour.rs
+++ b/market/src/behaviour.rs
@@ -9,7 +9,7 @@ use libp2p::{
     swarm::{behaviour::toggle::Toggle, NetworkBehaviour},
 };
 
-use crate::lmm::{FileInfoHash, SupplierInfo};
+use crate::lmm::{FileInfoHash, FileResponse};
 
 // TODO: maybe do somethign with toggle in future?
 
@@ -22,5 +22,5 @@ pub(crate) struct Behaviour {
     pub(crate) relay_server: Toggle<RelayServerBehaviour>,
     pub(crate) dcutr: Toggle<DcutrBehaviour>,
     pub(crate) relay_client: Toggle<RelayClientBehaviour>,
-    pub(crate) req_res: CborReqResBehaviour<FileInfoHash, SupplierInfo>,
+    pub(crate) req_res: CborReqResBehaviour<FileInfoHash, FileResponse>,
 }

--- a/market/src/bridge/peer.rs
+++ b/market/src/bridge/peer.rs
@@ -7,6 +7,7 @@ use tokio::sync::oneshot;
 
 use crate::command::request::KadRequest;
 use crate::command::request::LmmRequest;
+use crate::command::request::ReqResRequest;
 use crate::command::Message;
 use crate::FailureResponse;
 use crate::FileInfoHash;
@@ -92,6 +93,19 @@ impl Peer {
         } else {
             panic!("This should never run since there is no error ever sent back.")
         }
+    }
+
+    #[inline(always)]
+    pub async fn get_holder_by_peer_id(
+        &self,
+        peer_id: PeerId,
+        file_info_hash: impl Into<FileInfoHash>,
+    ) -> Response {
+        self.send(Request::ReqRes(ReqResRequest::GetHolderByPeerId {
+            peer_id,
+            file_info_hash: file_info_hash.into(),
+        }))
+        .await
     }
 
     #[inline(always)]

--- a/market/src/command/request.rs
+++ b/market/src/command/request.rs
@@ -16,7 +16,7 @@ pub(crate) enum Request {
     ConnectedTo { peer_id: PeerId },
     Kad(KadRequest),
     LocalMarketMap(LmmRequest),
-    RequestResponse(ReqResRequest),
+    ReqRes(ReqResRequest),
 }
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]

--- a/market/src/command/request.rs
+++ b/market/src/command/request.rs
@@ -16,6 +16,7 @@ pub(crate) enum Request {
     ConnectedTo { peer_id: PeerId },
     Kad(KadRequest),
     LocalMarketMap(LmmRequest),
+    RequestResponse(ReqResRequest),
 }
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
@@ -29,6 +30,14 @@ pub(crate) enum KadRequest {
         user: User,
     },
     GetProviders {
+        file_info_hash: FileInfoHash,
+    },
+}
+
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
+pub(crate) enum ReqResRequest {
+    GetHolderByPeerId {
+        peer_id: PeerId,
         file_info_hash: FileInfoHash,
     },
 }

--- a/market/src/command/response.rs
+++ b/market/src/command/response.rs
@@ -2,7 +2,7 @@ use libp2p::{Multiaddr, PeerId};
 use thiserror::Error;
 use tokio::sync::oneshot::error::RecvError;
 
-use crate::lmm::SupplierInfo;
+use crate::lmm::FileResponse;
 
 pub type Response = Result<SuccessfulResponse, FailureResponse>;
 
@@ -14,6 +14,7 @@ pub enum SuccessfulResponse {
     ConnectedTo { connected: bool },
     KadResponse(KadSuccessfulResponse),
     LmmResponse(LmmSuccessfulResponse),
+    ReqResResponse(ReqResSuccessfulResponse),
 }
 
 #[derive(Debug, PartialEq, Eq, Error)]
@@ -27,6 +28,8 @@ pub enum FailureResponse {
     KadError(KadFailureResponse),
     #[error("[Local Market Map Error] - {0}")]
     LmmError(LmmFailureResponse),
+    #[error("[Request Response Error] - {0}")]
+    ReqResError(ReqResFailureResponse),
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -61,5 +64,12 @@ pub enum LmmFailureResponse {}
 #[derive(Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum ReqResSuccessfulResponse {
-    GetHolderByPeerId { holder: SupplierInfo },
+    GetHolderByPeerId { holder: FileResponse },
+}
+
+#[derive(Debug, PartialEq, Eq, Error)]
+#[non_exhaustive]
+pub enum ReqResFailureResponse {
+    #[error("Failed to get holder by peer id: {error}")]
+    GetHolderByPeerId { error: String },
 }

--- a/market/src/command/response.rs
+++ b/market/src/command/response.rs
@@ -2,6 +2,8 @@ use libp2p::{Multiaddr, PeerId};
 use thiserror::Error;
 use tokio::sync::oneshot::error::RecvError;
 
+use crate::lmm::SupplierInfo;
+
 pub type Response = Result<SuccessfulResponse, FailureResponse>;
 
 #[derive(Debug, PartialEq, Eq)]
@@ -55,3 +57,9 @@ pub enum KadFailureResponse {
 #[derive(Debug, PartialEq, Eq, Error)]
 #[non_exhaustive]
 pub enum LmmFailureResponse {}
+
+#[derive(Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ReqResSuccessfulResponse {
+    GetHolderByPeerId { holder: SupplierInfo },
+}

--- a/market/src/handler/mod.rs
+++ b/market/src/handler/mod.rs
@@ -272,7 +272,7 @@ impl<'a> CommandRequestHandler for Handler<'a> {
                 let mut handler = LocalMarketMapHandler { lmm: self.lmm };
                 handler.handle_command(lmm_request, responder);
             }
-            Request::RequestResponse(req_res_request) => {
+            Request::ReqRes(req_res_request) => {
                 let mut handler = ReqResHandler::new(self.swarm, self.lmm, self.query_handler);
                 handler.handle_command(req_res_request, responder);
             }

--- a/market/src/handler/mod.rs
+++ b/market/src/handler/mod.rs
@@ -272,6 +272,10 @@ impl<'a> CommandRequestHandler for Handler<'a> {
                 let mut handler = LocalMarketMapHandler { lmm: self.lmm };
                 handler.handle_command(lmm_request, responder);
             }
+            Request::RequestResponse(req_res_request) => {
+                let mut handler = ReqResHandler::new(self.swarm, self.lmm, self.query_handler);
+                handler.handle_command(req_res_request, responder);
+            }
         };
     }
 }

--- a/market/src/handler/req_res.rs
+++ b/market/src/handler/req_res.rs
@@ -3,6 +3,7 @@ use libp2p::{
     Swarm,
 };
 use log::{error, info, warn};
+use tokio::sync::oneshot::Sender;
 
 use crate::{
     behaviour::Behaviour,
@@ -12,7 +13,7 @@ use crate::{
     },
     handler::send_ok,
     lmm::{FileInfoHash, FileResponse, LocalMarketMap},
-    FailureResponse, ReqResFailureResponse, ReqResSuccessfulResponse, SuccessfulResponse,
+    FailureResponse, ReqResFailureResponse, ReqResSuccessfulResponse, Response, SuccessfulResponse,
 };
 
 use super::{CommandRequestHandler, EventHandler};
@@ -129,11 +130,7 @@ impl<'a> EventHandler for ReqResHandler<'a> {
 impl<'a> CommandRequestHandler for ReqResHandler<'a> {
     type Request = ReqResRequest;
 
-    fn handle_command(
-        &mut self,
-        request: Self::Request,
-        responder: tokio::sync::oneshot::Sender<crate::Response>,
-    ) {
+    fn handle_command(&mut self, request: Self::Request, responder: Sender<Response>) {
         match request {
             ReqResRequest::GetHolderByPeerId {
                 peer_id,

--- a/market/src/handler/req_res.rs
+++ b/market/src/handler/req_res.rs
@@ -1,4 +1,8 @@
-use libp2p::{request_response::Event, Swarm};
+use libp2p::{
+    request_response::{Event, Message},
+    Swarm,
+};
+use log::{error, info, warn};
 
 use crate::{
     behaviour::Behaviour,
@@ -6,7 +10,9 @@ use crate::{
         request::{Query, ReqResRequest},
         QueryHandler,
     },
+    handler::send_ok,
     lmm::{FileInfoHash, FileResponse, LocalMarketMap},
+    FailureResponse, ReqResFailureResponse, ReqResSuccessfulResponse, SuccessfulResponse,
 };
 
 use super::{CommandRequestHandler, EventHandler};
@@ -36,18 +42,86 @@ impl<'a> EventHandler for ReqResHandler<'a> {
 
     fn handle_event(&mut self, event: Self::Event) {
         match event {
-            Event::Message { peer, message } => todo!(),
+            Event::Message { peer, message } => match message {
+                Message::Request {
+                    request_id,
+                    request,
+                    channel,
+                } => {
+                    info!(
+                        "[RequestResponse {request_id:?}] - Received request from {}",
+                        peer
+                    );
+                    let response = {
+                        if let Some(holder) = self.lmm.get_if_not_expired(&request) {
+                            info!("[RequestResponse {request_id:?}] - Found holder for file");
+                            FileResponse::HasFile(holder)
+                        } else {
+                            warn!("[RequestResponse {request_id:?}] - No holder found for file");
+                            FileResponse::NoFile
+                        }
+                    };
+
+                    if self
+                        .swarm
+                        .behaviour_mut()
+                        .req_res
+                        .send_response(channel, response)
+                        .is_err()
+                    {
+                        error!(
+                                "[RequestResponse {request_id:?}] - Failed to send response to {peer}. Could be timeout or channel closed.",
+                            );
+                    }
+                }
+                Message::Response {
+                    request_id,
+                    response,
+                } => {
+                    info!(
+                        "[RequestResponse {request_id:?}] - Received response from {}",
+                        peer
+                    );
+                    self.query_handler.respond(
+                        Query::ReqRes(request_id),
+                        Ok(SuccessfulResponse::ReqResResponse(
+                            ReqResSuccessfulResponse::GetHolderByPeerId { holder: response },
+                        )),
+                    );
+                }
+            },
             Event::OutboundFailure {
                 peer,
                 request_id,
                 error,
-            } => todo!(),
+            } => {
+                error!(
+                    "[RequestResponse {request_id:?}] - Outbound request failure to peer: {}",
+                    peer
+                );
+                self.query_handler.respond(
+                    Query::ReqRes(request_id),
+                    Err(FailureResponse::ReqResError(
+                        ReqResFailureResponse::GetHolderByPeerId {
+                            error: error.to_string(),
+                        },
+                    )),
+                );
+            }
             Event::InboundFailure {
                 peer,
                 request_id,
                 error,
-            } => todo!(),
-            Event::ResponseSent { peer, request_id } => todo!(),
+            } => {
+                error!(
+                    "[RequestResponse {request_id:?}] - Inbound request failure by trying to retrieve from peer: {}",
+                    peer
+                );
+                error!("[RequestResponse {request_id:?}] - Error: {}", error);
+            }
+            Event::ResponseSent { peer, request_id } => {
+                warn!("[RequestResponse {request_id:?}] - Response sent to peer: {peer}");
+            }
         }
     }
 }
@@ -65,12 +139,31 @@ impl<'a> CommandRequestHandler for ReqResHandler<'a> {
                 peer_id,
                 file_info_hash,
             } => {
-                let qid = self
-                    .swarm
-                    .behaviour_mut()
-                    .req_res
-                    .send_request(&peer_id, file_info_hash);
-                self.query_handler.add_query(Query::ReqRes(qid), responder);
+                if &peer_id == self.swarm.local_peer_id() {
+                    info!("[RequestResponse] - Requesting file from self");
+                    let response = {
+                        if let Some(holder) = self.lmm.get_if_not_expired(&file_info_hash) {
+                            info!("[RequestResponse] - Found holder for file from self");
+                            FileResponse::HasFile(holder)
+                        } else {
+                            warn!("[RequestResponse] - No holder found for file from self");
+                            FileResponse::NoFile
+                        }
+                    };
+                    send_ok!(
+                        responder,
+                        SuccessfulResponse::ReqResResponse(
+                            ReqResSuccessfulResponse::GetHolderByPeerId { holder: response }
+                        )
+                    );
+                } else {
+                    let qid = self
+                        .swarm
+                        .behaviour_mut()
+                        .req_res
+                        .send_request(&peer_id, file_info_hash);
+                    self.query_handler.add_query(Query::ReqRes(qid), responder);
+                }
             }
         }
     }

--- a/market/src/handler/req_res.rs
+++ b/market/src/handler/req_res.rs
@@ -6,7 +6,7 @@ use crate::{
         request::{Query, ReqResRequest},
         QueryHandler,
     },
-    lmm::{FileInfoHash, FileResponse, LocalMarketMap, SupplierInfo},
+    lmm::{FileInfoHash, FileResponse, LocalMarketMap},
 };
 
 use super::{CommandRequestHandler, EventHandler};

--- a/market/src/lib.rs
+++ b/market/src/lib.rs
@@ -16,7 +16,7 @@ pub use libp2p::{
     multiaddr::{multiaddr, Protocol},
     Multiaddr,
 };
-pub use lmm::FileInfoHash;
+pub use lmm::{FileInfoHash, FileResponse, SupplierInfo};
 
 pub(crate) mod behaviour;
 pub(crate) mod command;

--- a/market/src/lmm.rs
+++ b/market/src/lmm.rs
@@ -92,7 +92,7 @@ pub struct SupplierInfo {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub(crate) enum FileResponse {
+pub enum FileResponse {
     HasFile(SupplierInfo),
     NoFile,
 }

--- a/market/src/lmm.rs
+++ b/market/src/lmm.rs
@@ -91,6 +91,12 @@ pub(crate) struct SupplierInfo {
     pub(crate) user: User,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub(crate) enum FileResponse {
+    HasFile(SupplierInfo),
+    NoFile,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/market/src/lmm.rs
+++ b/market/src/lmm.rs
@@ -86,9 +86,9 @@ impl From<FileInfoHash> for Vec<u8> {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub(crate) struct SupplierInfo {
-    pub(crate) file_info: FileInfo,
-    pub(crate) user: User,
+pub struct SupplierInfo {
+    pub file_info: FileInfo,
+    pub user: User,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]

--- a/market/tests/test_check_holders.rs
+++ b/market/tests/test_check_holders.rs
@@ -1,0 +1,42 @@
+use orcanet_market::{
+    bridge::spawn, Config, FileInfoHash, FileResponse, ReqResSuccessfulResponse,
+    SuccessfulResponse, SupplierInfo,
+};
+use proto::market::{FileInfo, User};
+
+#[tokio::test]
+async fn test_register_file_and_get_self_holder() {
+    let config = Config::builder().set_peer_tcp_port(3390).build();
+    let peer = spawn(config).unwrap();
+    let peer_id = *peer.peer_id();
+    let user = User {
+        id: "abc".to_string(),
+        name: "helloworld".to_string(),
+        ip: "127.0.0.1".to_string(),
+        port: 6666,
+        price: 32,
+    };
+    let file_info = FileInfo {
+        file_hash: "123abc".to_string(),
+        chunk_hashes: vec!["hi".to_string()],
+        file_size: 3212321,
+        file_name: "fooobar.mp4".to_owned(),
+    };
+    let expected_holder = SupplierInfo {
+        file_info: file_info.clone(),
+        user: user.clone(),
+    };
+    let file_info_hash = FileInfoHash::new(file_info.hash_to_string());
+    let _ = peer
+        .register_file(user, file_info_hash.clone(), file_info)
+        .await;
+    let res = peer.get_holder_by_peer_id(peer_id, file_info_hash).await;
+    assert_eq!(
+        res,
+        Ok(SuccessfulResponse::ReqResResponse(
+            ReqResSuccessfulResponse::GetHolderByPeerId {
+                holder: FileResponse::HasFile(expected_holder)
+            }
+        ))
+    )
+}


### PR DESCRIPTION
# Description

Related to sbu-416-24sp/orcanet-rust#18.

This is another helper method for `check_holders` that we will allow public usability for the user.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] `test_check_holders.rs now has another test `test_register_file_and_get_self_holder`, which tests for if self is the local holder. Haven't directly set up another peer in this test yet but the functionality is same as what we had in a previous PoC.
- [x] Compiles with `cargo nextest run --test test_check_holders; links to the library so the library compiles

**Will add a test in the future for two peers that are connected and show that the request response works.**

## Running `test_check_holders` on my machine
Ran with `cargo nextest run --test test_check_holders`

![image](https://github.com/daminals/orcanet-rust/assets/65320857/a82f92ae-2b5b-4c3c-903b-b84d0ab86b16)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works (somewhat. Autonat isn't implemented so typically would crash due to `todo`, but the behavior of the method would be the same regardless.)
- [x] New and existing unit tests pass locally with my changes