### PR TITLE
feat(peer): implement the required check_holders method

### DIFF
--- a/market/src/bridge/peer.rs
+++ b/market/src/bridge/peer.rs
@@ -112,20 +112,10 @@ impl Peer {
     }
 
     pub async fn get_providers(&self, file_info_hash: impl Into<FileInfoHash>) -> Response {
-        let file_info_hash: FileInfoHash = file_info_hash.into();
-        let is_local_file_owner = self.is_local_file_owner(file_info_hash.clone()).await;
-        let mut res = self
-            .send(Request::Kad(KadRequest::GetProviders { file_info_hash }))
-            .await;
-        if let Ok(SuccessfulResponse::KadResponse(KadSuccessfulResponse::GetProviders {
-            ref mut providers,
-        })) = res
-        {
-            if is_local_file_owner {
-                providers.push(*self.peer_id());
-            }
-        }
-        res
+        self.send(Request::Kad(KadRequest::GetProviders {
+            file_info_hash: file_info_hash.into(),
+        }))
+        .await
     }
 
     #[inline(always)]

--- a/market/src/command/response.rs
+++ b/market/src/command/response.rs
@@ -1,4 +1,5 @@
 use libp2p::{Multiaddr, PeerId};
+use proto::market::HoldersResponse;
 use thiserror::Error;
 use tokio::sync::oneshot::error::RecvError;
 
@@ -12,6 +13,7 @@ pub enum SuccessfulResponse {
     Listeners { listeners: Vec<Multiaddr> },
     ConnectedPeers { peers: Vec<PeerId> },
     ConnectedTo { connected: bool },
+    CheckHolders(HoldersResponse),
     KadResponse(KadSuccessfulResponse),
     LmmResponse(LmmSuccessfulResponse),
     ReqResResponse(ReqResSuccessfulResponse),

--- a/market/src/handler/kad.rs
+++ b/market/src/handler/kad.rs
@@ -104,30 +104,28 @@ impl<'a> KadHandler<'a> {
             }
             QueryResult::GetProviders(result) => match result {
                 Ok(maybe_ok) => {
-                    if step.last {
-                        match maybe_ok {
-                            GetProvidersOk::FoundProviders { providers, .. } => {
-                                info!("[Kademlia] - GetProviders query successful");
-                                self.query_handler.respond(
-                                    Query::Kad(qid),
-                                    Ok(SuccessfulResponse::KadResponse(
-                                        KadSuccessfulResponse::GetProviders {
-                                            providers: providers.into_iter().collect(),
-                                        },
-                                    )),
-                                );
-                            }
-                            GetProvidersOk::FinishedWithNoAdditionalRecord { .. } => {
-                                warn!("[Kademlia] - GetProviders query didn't necessarily fail, but no additional records were found.");
-                                self.query_handler.respond(
-                                    Query::Kad(qid),
-                                    Ok(SuccessfulResponse::KadResponse(
-                                        KadSuccessfulResponse::GetProviders {
-                                            providers: Default::default(),
-                                        },
-                                    )),
-                                );
-                            }
+                    match maybe_ok {
+                        GetProvidersOk::FoundProviders { providers, .. } => {
+                            info!("[Kademlia] - GetProviders query successful");
+                            self.query_handler.respond(
+                                Query::Kad(qid),
+                                Ok(SuccessfulResponse::KadResponse(
+                                    KadSuccessfulResponse::GetProviders {
+                                        providers: providers.into_iter().collect(),
+                                    },
+                                )),
+                            );
+                        }
+                        GetProvidersOk::FinishedWithNoAdditionalRecord { .. } => {
+                            warn!("[Kademlia] - GetProviders query didn't necessarily fail, but no additional records were found.");
+                            self.query_handler.respond(
+                                Query::Kad(qid),
+                                Ok(SuccessfulResponse::KadResponse(
+                                    KadSuccessfulResponse::GetProviders {
+                                        providers: Default::default(),
+                                    },
+                                )),
+                            );
                         }
                     };
                 }

--- a/market/src/handler/kad.rs
+++ b/market/src/handler/kad.rs
@@ -163,6 +163,14 @@ impl<'a> KadHandler<'a> {
                     )
                 }
             },
+            QueryResult::RepublishProvider(result) => match result {
+                Ok(AddProviderOk { .. }) => {
+                    info!("[Kademlia] - Successfully republished the key");
+                }
+                Err(AddProviderError::Timeout { .. }) => {
+                    error!("[Kademlia] - Failed to republish the key due to timeout.")
+                }
+            },
             _ => {}
         }
     }

--- a/market/src/handler/mod.rs
+++ b/market/src/handler/mod.rs
@@ -79,8 +79,8 @@ impl<'a> EventHandler for Handler<'a> {
                     ping_handler.handle_event(event);
                 }
                 BehaviourEvent::Autonat(event) => {
-                    // let mut autonat_handler = AutoNatHandler::new(self.boot_nodes);
-                    // autonat_handler.handle_event(event);
+                    let mut autonat_handler = AutoNatHandler::new(self.boot_nodes);
+                    autonat_handler.handle_event(event);
                 }
                 BehaviourEvent::RelayServer(event) => {
                     let mut relay_server_handler = RelayServerHandler {};

--- a/market/src/handler/mod.rs
+++ b/market/src/handler/mod.rs
@@ -79,8 +79,8 @@ impl<'a> EventHandler for Handler<'a> {
                     ping_handler.handle_event(event);
                 }
                 BehaviourEvent::Autonat(event) => {
-                    let mut autonat_handler = AutoNatHandler::new(self.boot_nodes);
-                    autonat_handler.handle_event(event);
+                    // let mut autonat_handler = AutoNatHandler::new(self.boot_nodes);
+                    // autonat_handler.handle_event(event);
                 }
                 BehaviourEvent::RelayServer(event) => {
                     let mut relay_server_handler = RelayServerHandler {};

--- a/market/tests/test_check_holders.rs
+++ b/market/tests/test_check_holders.rs
@@ -1,6 +1,9 @@
+use std::{net::Ipv4Addr, time::Duration};
+
+use libp2p::Multiaddr;
 use orcanet_market::{
-    bridge::spawn, Config, FileInfoHash, FileResponse, ReqResSuccessfulResponse,
-    SuccessfulResponse, SupplierInfo,
+    bridge::spawn, BootNodes, Config, FileInfoHash, FileResponse, Protocol,
+    ReqResSuccessfulResponse, SuccessfulResponse, SupplierInfo,
 };
 use proto::market::{FileInfo, HoldersResponse, User};
 
@@ -67,5 +70,50 @@ async fn test_register_file_and_check_holders_basic() {
         .register_file(user, file_info_hash.clone(), file_info)
         .await;
     let res = peer.check_holders(file_info_hash).await;
+    assert_eq!(res, Ok(SuccessfulResponse::CheckHolders(expected_holders)))
+}
+
+#[tokio::test]
+async fn test_check_holders_from_other_peer() {
+    let config = Config::builder().set_peer_tcp_port(3392).build();
+    let peer1 = spawn(config).unwrap();
+    let mut addr = Multiaddr::empty();
+    addr.push(Protocol::Ip4(Ipv4Addr::LOCALHOST));
+    addr.push(Protocol::Tcp(3392));
+    addr.push(Protocol::P2p(*peer1.peer_id()));
+
+    let boot_nodes = BootNodes::with_nodes(vec![addr]);
+    let config = Config::builder()
+        .set_peer_tcp_port(3393)
+        .set_boot_nodes(boot_nodes)
+        .build();
+    let peer2 = spawn(config).unwrap();
+    // give it a bit to connect
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    let user = User {
+        id: "abc".to_string(),
+        name: "helloworld".to_string(),
+        ip: "127.0.0.1".to_string(),
+        port: 6666,
+        price: 32,
+    };
+    let file_info = FileInfo {
+        file_hash: "123abc".to_string(),
+        chunk_hashes: vec!["hi".to_string()],
+        file_size: 3212321,
+        file_name: "fooobar.mp4".to_owned(),
+    };
+    let expected_holders = HoldersResponse {
+        file_info: Some(file_info.clone()),
+        holders: vec![user.clone()],
+    };
+
+    let file_info_hash = FileInfoHash::new(file_info.hash_to_string());
+    let _ = peer1
+        .register_file(user, file_info_hash.clone(), file_info)
+        .await;
+    tokio::time::sleep(Duration::from_secs(1)).await;
+    let res = peer2.check_holders(file_info_hash).await;
     assert_eq!(res, Ok(SuccessfulResponse::CheckHolders(expected_holders)))
 }

--- a/market/tests/test_check_holders.rs
+++ b/market/tests/test_check_holders.rs
@@ -75,9 +75,6 @@ async fn test_register_file_and_check_holders_basic() {
 
 #[tokio::test]
 async fn test_check_holders_from_other_peer() {
-    let mut public_addr = Multiaddr::empty();
-    public_addr.push(Protocol::Ip4(Ipv4Addr::LOCALHOST));
-    public_addr.push(Protocol::Tcp(3392));
     let config = Config::builder().set_peer_tcp_port(3392).build();
     let peer1 = spawn(config).unwrap();
     let mut addr = Multiaddr::empty();

--- a/market/tests/test_check_holders.rs
+++ b/market/tests/test_check_holders.rs
@@ -1,4 +1,4 @@
-use std::{net::Ipv4Addr, time::Duration};
+use std::net::Ipv4Addr;
 
 use libp2p::Multiaddr;
 use orcanet_market::{
@@ -75,6 +75,9 @@ async fn test_register_file_and_check_holders_basic() {
 
 #[tokio::test]
 async fn test_check_holders_from_other_peer() {
+    let mut public_addr = Multiaddr::empty();
+    public_addr.push(Protocol::Ip4(Ipv4Addr::LOCALHOST));
+    public_addr.push(Protocol::Tcp(3392));
     let config = Config::builder().set_peer_tcp_port(3392).build();
     let peer1 = spawn(config).unwrap();
     let mut addr = Multiaddr::empty();
@@ -88,8 +91,6 @@ async fn test_check_holders_from_other_peer() {
         .set_boot_nodes(boot_nodes)
         .build();
     let peer2 = spawn(config).unwrap();
-    // give it a bit to connect
-    tokio::time::sleep(Duration::from_secs(1)).await;
 
     let user = User {
         id: "abc".to_string(),
@@ -113,7 +114,6 @@ async fn test_check_holders_from_other_peer() {
     let _ = peer1
         .register_file(user, file_info_hash.clone(), file_info)
         .await;
-    tokio::time::sleep(Duration::from_secs(1)).await;
     let res = peer2.check_holders(file_info_hash).await;
     assert_eq!(res, Ok(SuccessfulResponse::CheckHolders(expected_holders)))
 }

--- a/market/tests/test_check_holders.rs
+++ b/market/tests/test_check_holders.rs
@@ -2,7 +2,7 @@ use orcanet_market::{
     bridge::spawn, Config, FileInfoHash, FileResponse, ReqResSuccessfulResponse,
     SuccessfulResponse, SupplierInfo,
 };
-use proto::market::{FileInfo, User};
+use proto::market::{FileInfo, HoldersResponse, User};
 
 #[tokio::test]
 async fn test_register_file_and_get_self_holder() {
@@ -39,4 +39,33 @@ async fn test_register_file_and_get_self_holder() {
             }
         ))
     )
+}
+
+#[tokio::test]
+async fn test_register_file_and_check_holders_basic() {
+    let config = Config::builder().set_peer_tcp_port(3391).build();
+    let peer = spawn(config).unwrap();
+    let user = User {
+        id: "abc".to_string(),
+        name: "helloworld".to_string(),
+        ip: "127.0.0.1".to_string(),
+        port: 6666,
+        price: 32,
+    };
+    let file_info = FileInfo {
+        file_hash: "123abc".to_string(),
+        chunk_hashes: vec!["hi".to_string()],
+        file_size: 3212321,
+        file_name: "fooobar.mp4".to_owned(),
+    };
+    let expected_holders = HoldersResponse {
+        file_info: Some(file_info.clone()),
+        holders: vec![user.clone()],
+    };
+    let file_info_hash = FileInfoHash::new(file_info.hash_to_string());
+    let _ = peer
+        .register_file(user, file_info_hash.clone(), file_info)
+        .await;
+    let res = peer.check_holders(file_info_hash).await;
+    assert_eq!(res, Ok(SuccessfulResponse::CheckHolders(expected_holders)))
 }

--- a/market/tests/test_register_file.rs
+++ b/market/tests/test_register_file.rs
@@ -30,7 +30,7 @@ async fn test_register_file() {
 }
 
 #[tokio::test]
-async fn test_register_and_get_providers() {
+async fn test_register_and_get_providers_for_one() {
     let config = Config::builder().set_peer_tcp_port(14000).build();
     let peer = spawn(config).unwrap();
     let peer_id = peer.peer_id();


### PR DESCRIPTION
# Description

Fixes sbu-416-24sp/orcanet-rust#18.

We implement the `check_holders` method with this PR here.

- Another change is fixing the Kademlia providers part where we remove `step.last` since that only accounted for getting the `FoundWithNoAdditionalRecords` event which isn't what we need.
- Another change is that the Kademlia starts in `Mode::Server` by default and the comment for why is mentioned in `bridge/mod.rs`.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] `test_register_file_and_check_holders_basic` presents a new basic test for getting holders after registering a file on a single peer and then calling check holders which should return itself
- [x] `test_check_holders_from_other_peer` presents another test where we create two `Peer`s. The first peer spawns. The second peer spawns and has the first peer as a boot node. The first peer now registers a file and the second peer calls a `check_holders` which is expected to retrieve the first peer as a holder.
- [x] Compiles with `cargo test test_register_file`; links to the library so the library compiles

## Running `test_register_file` on my machine
![image](https://github.com/daminals/orcanet-rust/assets/65320857/2d604c1c-4fd7-4515-9ff7-7fd9e0163c5a)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works (somewhat. Autonat isn't implemented so typically would crash due to `todo`, but the behavior of the method would be the same regardless.)
- [x] New and existing unit tests pass locally with my changes